### PR TITLE
Optimize import of ecsy-babylon

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,15 @@ const EcsyModiferTransform = require('./lib/ast-transform');
 
 module.exports = {
   name: require('./package').name,
-
+  options: {
+    autoImport: {
+      alias: {
+        // explicitly use the ESM build. ember-auto-import will otherwise default to the browser build, which is a
+        // gigantic UMD build including all of Babylon.js, not allowing any tree-shaking
+        'ecsy-babylon': 'ecsy-babylon/dist/src/index.js',
+      },
+    },
+  },
   setupPreprocessorRegistry(type, registry) {
     const plugin = this._buildPlugin();
     plugin.parallelBabel = {


### PR DESCRIPTION
Explicitly use the ESM build. ember-auto-import will otherwise default to the browser build, which is a
gigantic UMD build including all of Babylon.js, not allowing any tree-shaking.

This reduced the `vendor.js` in GETWBC from 4MB to 3MB gzipped. Still way to big, but at least something. See also https://github.com/kaliber5/ecsy-babylon/issues/35