### PR TITLE
Pin TS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "loader.js": "^4.7.0",
     "pretender": "^3.3.1",
     "qunit-dom": "^1.0.0",
-    "typescript": "^3.6.4"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": "10.* || >= 12.*"


### PR DESCRIPTION
To make at least the floating dependency test pass again, and unlock all those dependabot PRs that are currently not mergable due to this. See https://github.com/typed-ember/ember-cli-typescript/issues/1103

fyi @nickschot 