### PR TITLE
Use direct imports of ecsy-babylon to support tree shaking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,10 +22,22 @@ module.exports = {
     browser: true
   },
   rules: {
-    'no-restricted-imports': ['error', {
-      name: '@babylonjs/core',
-      message: 'Don\'t import from @babylonjs/core, use a direct import instead! See https://doc.babylonjs.com/features/es6_support#tree-shaking'
-    }]
+    'no-restricted-imports': ['error',
+      {
+        name: '@babylonjs/core',
+        message: 'Don\'t import from @babylonjs/core, use a direct import instead! See https://doc.babylonjs.com/features/es6_support#tree-shaking'
+      },
+      {
+        name: 'ecsy-babylon',
+        message:
+          "Don't import from index modules of ecsy-babylon, use a direct import instead to support tree shaking! See https://github.com/ef4/ember-auto-import/issues/121",
+      },
+      {
+        name: 'ecsy-babylon/systems',
+        message:
+          "Don't import from index modules of ecsy-babylon, use a direct import instead to support tree shaking! See https://github.com/ef4/ember-auto-import/issues/121",
+      },
+    ]
   },
   overrides: [
     // ts files

--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ Usage
 [Longer description of how to use the addon in apps.]
 
 
+
+### Tree shaking
+
+Due to [this ember-auto-import bug](https://github.com/ef4/ember-auto-import/issues/121) 
+use direct imports of `ecsy-babylon` systems:
+
+```js
+// good
+import BabylonSystem from 'ecsy-babylon/systems/babylon';
+
+// bad
+import { BabylonSystem } from 'ecsy-babylon/systems';
+import { BabylonSystem } from 'ecsy-babylon';
+```
+
+Same applies when you import from `@babylonjs/core`, see [Tree Shaking of Babylon.js](https://doc.babylonjs.com/features/es6_support#tree-shaking)
+
+This will pull in only the needed systems, and as such also only the needed parts of `babylon.js`.
+
 Contributing
 ------------------------------------------------------------------------------
 

--- a/addon/components/ecsy-babylon.ts
+++ b/addon/components/ecsy-babylon.ts
@@ -1,5 +1,5 @@
 import Ecsy, { EcsyArgs, EcsyContext } from 'ember-ecsy-babylon/components/ecsy';
-import { BabylonCore } from 'ecsy-babylon';
+import BabylonCore from 'ecsy-babylon/components/babylon-core';
 import { Entity } from 'ecsy';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';

--- a/addon/components/ecsy-babylon/load-gltfs.ts
+++ b/addon/components/ecsy-babylon/load-gltfs.ts
@@ -1,6 +1,6 @@
 import DomlessGlimmerComponent from 'ember-ecsy-babylon/components/domless-glimmer';
 import {assert} from '@ember/debug';
-import { BabylonCore } from 'ecsy-babylon';
+import BabylonCore from 'ecsy-babylon/components/babylon-core';
 import { hash } from 'ember-concurrency';
 import { restartableTask, task } from 'ember-concurrency-decorators';
 import { tracked } from '@glimmer/tracking';

--- a/addon/components/ecsy-babylon/scene.ts
+++ b/addon/components/ecsy-babylon/scene.ts
@@ -1,6 +1,6 @@
 import DomlessGlimmerComponent from 'ember-ecsy-babylon/components/domless-glimmer';
 import { assert } from '@ember/debug';
-import { BabylonCore } from 'ecsy-babylon';
+import BabylonCore from 'ecsy-babylon/components/babylon-core';
 import {
   EcsyBabylonContext, EcsyBabylonDomlessGlimmerArgs
 } from 'ember-ecsy-babylon/components/ecsy-babylon';

--- a/addon/components/ecsy.ts
+++ b/addon/components/ecsy.ts
@@ -1,7 +1,7 @@
 import DomlessGlimmerComponent, { DomlessGlimmerArgs } from 'ember-ecsy-babylon/components/domless-glimmer';
 import { Component as EcsyComponent, ComponentConstructor, System as EcsySystem, SystemConstructor, World } from 'ecsy';
 import { assert } from '@ember/debug';
-import { Parent } from 'ecsy-babylon';
+import Parent from 'ecsy-babylon/components/parent';
 
 export interface EcsyArgs<C extends EcsyContext> extends DomlessGlimmerArgs<C> {
   components: Map<string, ComponentConstructor<EcsyComponent<unknown>>>;

--- a/addon/components/ecsy/entity.ts
+++ b/addon/components/ecsy/entity.ts
@@ -1,6 +1,6 @@
 import { Entity } from 'ecsy';
 import { assert } from '@ember/debug';
-import { Parent } from 'ecsy-babylon';
+import Parent from 'ecsy-babylon/components/parent';
 import DomlessGlimmerComponent, { DomlessGlimmerArgs } from 'ember-ecsy-babylon/components/domless-glimmer';
 import { EcsyContext } from 'ember-ecsy-babylon/components/ecsy';
 

--- a/tests/dummy/app/controllers/application.ts
+++ b/tests/dummy/app/controllers/application.ts
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { VideoTexture } from '@babylonjs/core/Materials/Textures/videoTexture';
 import { tracked } from '@glimmer/tracking';
 import * as components from 'ecsy-babylon/components';
+// eslint-disable-next-line no-restricted-imports
 import { systems } from 'ecsy-babylon';
 import { mapComponentImports } from 'ember-ecsy-babylon';
 

--- a/tests/helpers/setup-ecsy-babylon.ts
+++ b/tests/helpers/setup-ecsy-babylon.ts
@@ -1,9 +1,10 @@
 import * as components from 'ecsy-babylon/components';
+// eslint-disable-next-line no-restricted-imports
 import { systems } from 'ecsy-babylon';
 import { mapComponentImports } from 'ember-ecsy-babylon';
 import { TestContext } from "ember-test-helpers";
 
-export default function setupEcsyBabylon(hooks: NestedHooks) {
+export default function setupEcsyBabylon(hooks: NestedHooks): void {
   hooks.beforeEach(function(this: TestContext) {
     this.set('components', mapComponentImports(components));
     this.set('systems', systems);


### PR DESCRIPTION
Workaround until https://github.com/ef4/ember-auto-import/issues/121 is resolved.