### PR TITLE
Make AST transform idempotent

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -30,14 +30,14 @@ class EcsyModifierTransform {
       ElementNode(node) {
         const tagParts = node.tag.split(".");
 
-        if (tagParts.length === 2 && ['Entity', 'LoadGltf', 'LoadGltfs'].includes(tagParts[1])) {
+        if (tagParts.length === 2 && ['Entity', 'LoadGltf', 'LoadGltfs'].includes(tagParts[1]) && !node.blockParams.includes('parent')) {
           node.selfClosing = false;
           node.blockParams = [...node.blockParams, "parent"];
           node.attributes = [
             ...node.attributes,
             b.attr("@parent", b.mustache("parent"))
           ];
-        } else if (tagParts.length === 1 && ['Scene', 'Ecsy'].includes(tagParts[0])) {
+        } else if (tagParts.length === 1 && ['Scene', 'Ecsy'].includes(tagParts[0]) && !node.blockParams.includes('parent')) {
           node.selfClosing = false;
           node.blockParams = [...node.blockParams, "parent"];
         }


### PR DESCRIPTION
Running the transform multiple times on the same template can happen when used in an addon.