### PR TITLE
Use canvas reference without relying on custom ID

### DIFF
--- a/addon/components/ecsy-babylon.hbs
+++ b/addon/components/ecsy-babylon.hbs
@@ -3,24 +3,23 @@
   {{did-insert this.onCanvasReady}}
   {{on "keypress" this.toggleBabylonInspector}}
   ...attributes>
-{{#if (has-block "ecsy")}}
-  {{#if this.ready}}
-    {{yield
-      (component "ecsy-babylon/scene"
-        parent=this
-      )
-      to="ecsy"
-    }}
+  {{#if (has-block "ecsy")}}
+    {{#if this.ready}}
+      {{yield
+        (component "ecsy-babylon/scene"
+          parent=this
+        )
+        to="ecsy"
+      }}
+    {{/if}}
+    {{yield to="html"}}
+  {{else}}
+    {{#if this.ready}}
+      {{yield
+        (component "ecsy-babylon/scene"
+          parent=this
+        )
+      }}
+    {{/if}}
   {{/if}}
-  {{yield to="html"}}
-{{else}}
-  {{#if this.ready}}
-    {{yield
-      (component "ecsy-babylon/scene"
-        parent=this
-      )
-    }}
-  {{/if}}
-{{/if}}
-
 </canvas>

--- a/addon/components/ecsy-babylon.ts
+++ b/addon/components/ecsy-babylon.ts
@@ -1,7 +1,6 @@
 import Ecsy, { EcsyArgs, EcsyContext } from 'ember-ecsy-babylon/components/ecsy';
 import BabylonCore from 'ecsy-babylon/components/babylon-core';
 import { Entity } from 'ecsy';
-import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
@@ -27,8 +26,6 @@ const DEBUG_KEY = {
 }
 
 export default class EcsyBabylon extends Ecsy<EcsyBabylonContext, EcsyBabylonDomlessGlimmerArgs> {
-  guid = guidFor(this);
-
   entity: Entity;
   scene?: Scene;
 
@@ -45,10 +42,7 @@ export default class EcsyBabylon extends Ecsy<EcsyBabylonContext, EcsyBabylonDom
   }
 
   @action
-  onCanvasReady(): void {
-    const canvas = document.getElementById(`${this.guid}__canvas`) as HTMLCanvasElement;
-    assert('Canvas element needed', canvas);
-
+  onCanvasReady(canvas: HTMLCanvasElement): void {
     const engine = new Engine(canvas, this.args.antialias, this.args.engineOptions, this.args.adaptToDeviceRatio);
 
     this.entity.addComponent(BabylonCore, {


### PR DESCRIPTION
Applying the ID was basically unnecessary, as we already get the element ref from the modifier. This also has the benefit that we can use an app with our canvas inside a shadowDOM, where `document.getElementById()` would return `null`.