### PR TITLE
Fix leaking object instances when updating ecsy components

### DIFF
--- a/addon/components/ecsy/ecsy-component.ts
+++ b/addon/components/ecsy/ecsy-component.ts
@@ -45,8 +45,18 @@ export default class EcsyComponent extends DomlessGlimmerComponent<EcsyContext, 
       parent,
     } = this.args;
 
+    const schema = this._Component.schema;
     const component = parent.entity.getMutableComponent(this._Component);
-    Object.assign(component, changedArgs);
+    assert(`No component "${this.args.name}" found to update.`, component);
+
+    for (const [key, value] of Object.entries(changedArgs)) {
+      const prop = schema[key];
+      if (prop) {
+        component[key as keyof _Component<unknown>] = prop.type.copy(value, component[key as keyof _Component<unknown>]);
+      } else {
+        component[key as keyof _Component<unknown>] = value;
+      }
+    }
   }
 
   willDestroy(): void {

--- a/tests/integration/components/ecsy/ecsy-component-test.ts
+++ b/tests/integration/components/ecsy/ecsy-component-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupDataDumper from 'dummy/tests/helpers/dump';
 import { Component, Types } from 'ecsy';
@@ -34,5 +34,46 @@ module('Integration | Component | ecsy/component', function(hooks) {
     const component = entity.getComponent(DummyComponent);
     assert.ok(component, 'entity has component');
     assert.equal(component.foo, 'bar', 'component has passed arguments');
+  });
+
+  test('it does not leak passed instances', async function(assert) {
+
+    class DummyComponent extends Component<DummyComponent> {
+      foo?: {};
+
+      static schema = {
+        foo: { type: Types.JSON }
+      }
+    }
+
+    this.set('components', new Map([['dummy', DummyComponent]]));
+
+    let instance = { bar: true };
+    this.set('instance', instance);
+
+    await render(hbs`
+      <Ecsy @systems={{array}} @components={{this.components}} as |world|>
+        {{dump world.world}}
+        <world.Entity {{dummy foo=this.instance}}/>
+      </Ecsy>
+    `);
+
+    const { entityManager } = getData() as any;
+    assert.equal(entityManager._entities.length, 1);
+    const entity = entityManager._entities[0];
+    let component = entity.getComponent(DummyComponent);
+    assert.ok(component, 'entity has component');
+    assert.deepEqual(component.foo, instance, 'component has passed argument');
+    assert.notStrictEqual(component.foo, instance, 'component has different instance');
+
+
+    instance = { bar: false };
+    this.set('instance', instance);
+    await settled();
+
+    component = entity.getComponent(DummyComponent);
+    assert.ok(component, 'entity has component');
+    assert.deepEqual(component.foo, instance, 'component has passed argument');
+    assert.notStrictEqual(component.foo, instance, 'component has different instance');
   });
 });


### PR DESCRIPTION
Instances of complex objects (e.g. `Vector3`) could leak between components, for instance into components taken from ecsy component pool.