### PR TITLE
Expose AssetContainer directly in `<LoadGltfs>`

### DIFF
--- a/addon/components/ecsy-babylon/load-gltfs.hbs
+++ b/addon/components/ecsy-babylon/load-gltfs.hbs
@@ -1,6 +1,4 @@
-{{#if this.assets}}
-  {{yield
-    this.assets
-    this
-  }}
-{{/if}}
+{{yield
+  this.assetContainerHash
+  this
+}}

--- a/tests/dummy/public/gltf/object3.gltf
+++ b/tests/dummy/public/gltf/object3.gltf
@@ -1,0 +1,142 @@
+{
+  "asset": {
+    "generator": "COLLADA2GLTF",
+    "version": "2.0"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "children": [
+        1
+      ],
+      "matrix": [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -1.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    {
+      "mesh": 0
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "NORMAL": 1,
+            "POSITION": 2
+          },
+          "indices": 0,
+          "mode": 4,
+          "material": 0
+        }
+      ],
+      "name": "Mesh"
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 36,
+      "max": [
+        23
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "min": [
+        -1.0,
+        -1.0,
+        -1.0
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 288,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "type": "VEC3"
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.800000011920929,
+          0.0,
+          0.0,
+          1.0
+        ],
+        "metallicFactor": 0.0
+      },
+      "name": "Red"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 576,
+      "byteLength": 72,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 576,
+      "byteStride": 12,
+      "target": 34962
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 648,
+      "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUA"
+    }
+  ]
+}

--- a/tests/helpers/dump.ts
+++ b/tests/helpers/dump.ts
@@ -1,9 +1,11 @@
 import { TestContext } from 'ember-test-helpers';
 import { helper } from '@ember/component/helper';
 
-export default function setupDataDumper(hooks: NestedHooks): () => unknown {
-  let data: unknown;
-  const dumpHelper = helper(function dump([argument]: unknown[]) {
+export default function setupDataDumper<T = unknown>(
+  hooks: NestedHooks
+): () => T | undefined {
+  let data: T | undefined;
+  const dumpHelper = helper(function dump([argument]: T[]) {
     data = argument;
   });
 

--- a/tests/integration/components/ecsy-babylon/load-gltf-test.ts
+++ b/tests/integration/components/ecsy-babylon/load-gltf-test.ts
@@ -24,7 +24,7 @@ module('Integration | Component | ecsy-babylon/load-gltf', function (hooks) {
 
     await waitUntil(getData);
     const data = getData() as AssetContainer;
-    assert.equal(data.meshes.length, 1);
+    assert.equal(data.meshes.length, 2);
     assert.equal(data.materials.length, 1);
   });
 
@@ -41,7 +41,7 @@ module('Integration | Component | ecsy-babylon/load-gltf', function (hooks) {
 
     await waitUntil(getData);
     const data = getData() as AssetContainer;
-    assert.equal(data.meshes.length, 1);
+    assert.equal(data.meshes.length, 2);
     assert.equal(data.materials.length, 1);
   });
 });

--- a/tests/integration/components/ecsy-babylon/load-gltfs-test.ts
+++ b/tests/integration/components/ecsy-babylon/load-gltfs-test.ts
@@ -30,10 +30,10 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
     });
     const data = getData()!;
     assert.deepEqual(Object.keys(data), ['obj1', 'obj2']);
-    assert.equal(data.obj1.meshes.length, 2);
-    assert.equal(data.obj1.materials.length, 1);
-    assert.equal(data.obj2.meshes.length, 2);
-    assert.equal(data.obj2.materials.length, 1);
+    assert.equal(data.obj1?.meshes.length, 2);
+    assert.equal(data.obj1?.materials.length, 1);
+    assert.equal(data.obj2?.meshes.length, 2);
+    assert.equal(data.obj2?.materials.length, 1);
   });
 
   test('it supports GLB', async function (assert) {
@@ -53,10 +53,10 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
     });
     const data = getData()!;
     assert.deepEqual(Object.keys(data), ['obj1', 'obj2']);
-    assert.equal(data.obj1.meshes.length, 2);
-    assert.equal(data.obj1.materials.length, 1);
-    assert.equal(data.obj2.meshes.length, 2);
-    assert.equal(data.obj2.materials.length, 1);
+    assert.equal(data.obj1?.meshes.length, 2);
+    assert.equal(data.obj1?.materials.length, 1);
+    assert.equal(data.obj2?.meshes.length, 2);
+    assert.equal(data.obj2?.materials.length, 1);
   });
 
   test('it can update', async function (assert) {
@@ -80,8 +80,8 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
       return data && Object.keys(data).length;
     });
     const data1 = getData()!;
-    const data1obj1Mesh = data1.obj1.meshes[1];
-    const data1obj2Mesh = data1.obj2.meshes[1];
+    const data1obj1Mesh = data1.obj1?.meshes[1];
+    const data1obj2Mesh = data1.obj2?.meshes[1];
 
     this.set('files', {
       obj1: '/gltf/object1.gltf',
@@ -104,15 +104,15 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
       'Unchanged assets have the same container'
     );
 
-    assert.equal(data2.obj1.meshes.length, 2);
-    assert.notOk(data2.obj1.meshes[1].isDisposed());
-    assert.equal(data2.obj1.materials.length, 1);
-    assert.equal(data2.obj3.meshes.length, 2);
-    assert.notOk(data2.obj3.meshes[1].isDisposed());
-    assert.equal(data2.obj3.materials.length, 1);
+    assert.equal(data2.obj1?.meshes.length, 2);
+    assert.notOk(data2.obj1?.meshes[1].isDisposed());
+    assert.equal(data2.obj1?.materials.length, 1);
+    assert.equal(data2.obj3?.meshes.length, 2);
+    assert.notOk(data2.obj3?.meshes[1].isDisposed());
+    assert.equal(data2.obj3?.materials.length, 1);
 
-    assert.equal(data1.obj2.meshes.length, 0);
-    assert.ok(data1obj2Mesh.isDisposed());
+    assert.equal(data1.obj2?.meshes.length, 0);
+    assert.ok(data1obj2Mesh?.isDisposed());
 
     this.set('files', {
       obj1: '/gltf/object2.gltf',
@@ -134,12 +134,12 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
       'Changed assets have different container'
     );
 
-    assert.equal(data3.obj1.meshes.length, 2);
-    assert.notOk(data3.obj1.meshes[1].isDisposed());
-    assert.equal(data3.obj1.materials.length, 1);
+    assert.equal(data3.obj1?.meshes.length, 2);
+    assert.notOk(data3.obj1?.meshes[1].isDisposed());
+    assert.equal(data3.obj1?.materials.length, 1);
 
-    assert.equal(data1.obj1.meshes.length, 0);
-    assert.ok(data1obj1Mesh.isDisposed());
+    assert.equal(data1.obj1?.meshes.length, 0);
+    assert.ok(data1obj1Mesh?.isDisposed());
   });
 
   test('it disposes after teardown', async function (assert) {
@@ -161,17 +161,17 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
       return data && Object.keys(data).length;
     });
     const data = getData()!;
-    const mesh = data.obj1.meshes[1];
+    const mesh = data.obj1?.meshes[1];
 
     this.set('show', false);
     await settled();
     await timeout(50);
 
-    assert.equal(data.obj1.meshes.length, 0);
-    assert.equal(data.obj1.materials.length, 0);
-    assert.equal(data.obj2.meshes.length, 0);
-    assert.equal(data.obj2.materials.length, 0);
-    assert.ok(mesh.isDisposed());
+    assert.equal(data.obj1?.meshes.length, 0);
+    assert.equal(data.obj1?.materials.length, 0);
+    assert.equal(data.obj2?.meshes.length, 0);
+    assert.equal(data.obj2?.materials.length, 0);
+    assert.ok(mesh?.isDisposed());
   });
 
   test('it ignores non-loading assets', async function (assert) {
@@ -191,8 +191,8 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
     });
     const data = getData()!;
     assert.deepEqual(Object.keys(data), ['obj1', 'obj2']);
-    assert.equal(data.obj1.meshes.length, 2);
-    assert.equal(data.obj1.materials.length, 1);
+    assert.equal(data.obj1?.meshes.length, 2);
+    assert.equal(data.obj1?.materials.length, 1);
     assert.equal(data.obj2, null);
   });
 });

--- a/tests/integration/components/ecsy-babylon/load-gltfs-test.ts
+++ b/tests/integration/components/ecsy-babylon/load-gltfs-test.ts
@@ -1,15 +1,17 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, waitUntil } from '@ember/test-helpers';
+import { render, settled, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupDataDumper from 'dummy/tests/helpers/dump';
 import setupEcsyBabylon from 'dummy/tests/helpers/setup-ecsy-babylon';
 import { AssetContainerHash } from 'ember-ecsy-babylon/components/ecsy-babylon/load-gltfs';
+import { timeout } from 'ember-concurrency';
 
 module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
   setupRenderingTest(hooks);
   setupEcsyBabylon(hooks);
-  const getData = setupDataDumper(hooks);
+  const getData = setupDataDumper<AssetContainerHash>(hooks);
 
   test('it yields loaded asset hash', async function (assert) {
     await render(hbs`
@@ -22,12 +24,15 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
       </EcsyBabylon>
     `);
 
-    await waitUntil(getData);
-    const data = getData() as AssetContainerHash;
+    await waitUntil(() => {
+      const data = getData();
+      return data && Object.keys(data).length;
+    });
+    const data = getData()!;
     assert.deepEqual(Object.keys(data), ['obj1', 'obj2']);
-    assert.equal(data.obj1.meshes.length, 1);
+    assert.equal(data.obj1.meshes.length, 2);
     assert.equal(data.obj1.materials.length, 1);
-    assert.equal(data.obj2.meshes.length, 1);
+    assert.equal(data.obj2.meshes.length, 2);
     assert.equal(data.obj2.materials.length, 1);
   });
 
@@ -42,12 +47,152 @@ module('Integration | Component | ecsy-babylon/load-gltfs', function (hooks) {
       </EcsyBabylon>
     `);
 
-    await waitUntil(getData);
-    const data = getData() as AssetContainerHash;
+    await waitUntil(() => {
+      const data = getData();
+      return data && Object.keys(data).length;
+    });
+    const data = getData()!;
     assert.deepEqual(Object.keys(data), ['obj1', 'obj2']);
-    assert.equal(data.obj1.meshes.length, 1);
+    assert.equal(data.obj1.meshes.length, 2);
     assert.equal(data.obj1.materials.length, 1);
-    assert.equal(data.obj2.meshes.length, 1);
+    assert.equal(data.obj2.meshes.length, 2);
     assert.equal(data.obj2.materials.length, 1);
+  });
+
+  test('it can update', async function (assert) {
+    this.set('files', {
+      obj1: '/gltf/object1.gltf',
+      obj2: '/gltf/object2.gltf',
+    });
+
+    await render(hbs`
+      <EcsyBabylon @components={{this.components}} @systems={{this.systems}} as |Scene|>
+        <Scene as |World|>
+          <World.LoadGltfs @files={{this.files}} as |ach|>
+            {{dump ach}}
+          </World.LoadGltfs>
+        </Scene>
+      </EcsyBabylon>
+    `);
+
+    await waitUntil(() => {
+      const data = getData();
+      return data && Object.keys(data).length;
+    });
+    const data1 = getData()!;
+    const data1obj1Mesh = data1.obj1.meshes[1];
+    const data1obj2Mesh = data1.obj2.meshes[1];
+
+    this.set('files', {
+      obj1: '/gltf/object1.gltf',
+      obj3: '/gltf/object3.gltf',
+    });
+    await settled();
+    await waitUntil(() => {
+      const data = getData();
+      return data && 'obj3' in data;
+    });
+    await timeout(50);
+
+    const data2 = getData()!;
+    assert.deepEqual(Object.keys(data1), ['obj1', 'obj2']);
+    assert.deepEqual(Object.keys(data2), ['obj1', 'obj3']);
+
+    assert.strictEqual(
+      data1.obj1,
+      data2.obj1,
+      'Unchanged assets have the same container'
+    );
+
+    assert.equal(data2.obj1.meshes.length, 2);
+    assert.notOk(data2.obj1.meshes[1].isDisposed());
+    assert.equal(data2.obj1.materials.length, 1);
+    assert.equal(data2.obj3.meshes.length, 2);
+    assert.notOk(data2.obj3.meshes[1].isDisposed());
+    assert.equal(data2.obj3.materials.length, 1);
+
+    assert.equal(data1.obj2.meshes.length, 0);
+    assert.ok(data1obj2Mesh.isDisposed());
+
+    this.set('files', {
+      obj1: '/gltf/object2.gltf',
+      dummy: '/gltf/object3.gltf',
+    });
+    await settled();
+    await waitUntil(() => {
+      const data = getData();
+      return data && 'dummy' in data;
+    });
+    await timeout(50);
+
+    const data3 = getData()!;
+    assert.deepEqual(Object.keys(data3), ['obj1', 'dummy']);
+
+    assert.notStrictEqual(
+      data1.obj1,
+      data3.obj1,
+      'Changed assets have different container'
+    );
+
+    assert.equal(data3.obj1.meshes.length, 2);
+    assert.notOk(data3.obj1.meshes[1].isDisposed());
+    assert.equal(data3.obj1.materials.length, 1);
+
+    assert.equal(data1.obj1.meshes.length, 0);
+    assert.ok(data1obj1Mesh.isDisposed());
+  });
+
+  test('it disposes after teardown', async function (assert) {
+    this.set('show', true);
+    await render(hbs`
+      <EcsyBabylon @components={{this.components}} @systems={{this.systems}} as |Scene|>
+        <Scene as |World|>
+          {{#if this.show}}
+            <World.LoadGltfs @files={{hash obj1="/gltf/object1.gltf" obj2="/gltf/object2.gltf"}} as |ach|>
+              {{dump ach}}
+            </World.LoadGltfs>
+          {{/if}}
+        </Scene>
+      </EcsyBabylon>
+    `);
+
+    await waitUntil(() => {
+      const data = getData();
+      return data && Object.keys(data).length;
+    });
+    const data = getData()!;
+    const mesh = data.obj1.meshes[1];
+
+    this.set('show', false);
+    await settled();
+    await timeout(50);
+
+    assert.equal(data.obj1.meshes.length, 0);
+    assert.equal(data.obj1.materials.length, 0);
+    assert.equal(data.obj2.meshes.length, 0);
+    assert.equal(data.obj2.materials.length, 0);
+    assert.ok(mesh.isDisposed());
+  });
+
+  test('it ignores non-loading assets', async function (assert) {
+    await render(hbs`
+      <EcsyBabylon @components={{this.components}} @systems={{this.systems}} as |Scene|>
+        <Scene as |World|>
+          <World.LoadGltfs @files={{hash obj1="/gltf/object1.gltf" obj2="/gltf/xxx.gltf"}} as |ach|>
+            {{dump ach}}
+          </World.LoadGltfs>
+        </Scene>
+      </EcsyBabylon>
+    `);
+
+    await waitUntil(() => {
+      const data = getData();
+      return data && Object.keys(data).length;
+    });
+    const data = getData()!;
+    assert.deepEqual(Object.keys(data), ['obj1', 'obj2']);
+    assert.equal(data.obj1.meshes.length, 2);
+    assert.equal(data.obj1.materials.length, 1);
+    assert.equal(data.obj2, null);
   });
 });


### PR DESCRIPTION
Also removes unused keys from yielded hash, and improves test coverage.